### PR TITLE
Testcases

### DIFF
--- a/kagen/generators/geometric/rgg.cpp
+++ b/kagen/generators/geometric/rgg.cpp
@@ -120,7 +120,6 @@ PGeneratorConfig NormalizeParametersCommon(
 PGeneratorConfig
 RGG2DFactory::NormalizeParameters(PGeneratorConfig config, PEID, const PEID size, const bool output) const {
     EnsureSquarePowerOfTwoChunkSize(config, size, output);
-    // EnsurePowerOfTwoCommunicatorSize(config, size);
 
     return NormalizeParametersCommon(config, &ApproxRadius2D, &ApproxNumNodes2D, output);
 }
@@ -132,8 +131,7 @@ RGG2DFactory::Create(const PGeneratorConfig& config, const PEID rank, const PEID
 
 PGeneratorConfig
 RGG3DFactory::NormalizeParameters(PGeneratorConfig config, PEID, const PEID size, const bool output) const {
-    EnsureCubicPowerOfTwoChunkSize(config, size, output);
-    //EnsurePowerOfTwoCommunicatorSize(config, size);
+    EnsureSquarePowerOfTwoChunkSize(config, size, output);
 
     return NormalizeParametersCommon(config, &ApproxRadius3D, &ApproxNumNodes3D, output);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,5 +42,9 @@ kagen_add_test(test_generic_file_generator
     FILES file/generic_file_generator_test.cpp
     CORES 1 2 3 4 8 16)
 
+kagen_add_test(geometric_2d
+        FILES geometric/geometric_2d.cpp
+        CORES 1 2 3 4 8 16)
+
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,8 +42,13 @@ kagen_add_test(test_generic_file_generator
     FILES file/generic_file_generator_test.cpp
     CORES 1 2 3 4 8 16)
 
+# Geometric Generator
 kagen_add_test(geometric_2d
         FILES geometric/geometric_2d.cpp
+        CORES 1 2 3 4 8 16)
+
+kagen_add_test(geometric_3d
+        FILES geometric/geometric_3d.cpp
         CORES 1 2 3 4 8 16)
 
 

--- a/tests/geometric/geometric_2d.cpp
+++ b/tests/geometric/geometric_2d.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "kagen/context.h"
+#include "kagen/definitions.h"
+#include "kagen/generators/geometric/geometric_2d.h"
+#include "kagen/generators/geometric/rgg.h"
+
+using namespace kagen;
+
+bool sortByFirstElement(const std::pair<SInt, SInt>& lhs, const std::pair<SInt, SInt>& rhs) {
+    if (lhs.first == rhs.first) {
+        return lhs.second < rhs.second;
+    }
+    return lhs.first < rhs.first;
+}
+
+TEST(KARGB, generates_graph_on_one_PE) {
+    PGeneratorConfig config;
+    config.n = 16;
+    config.r = 0.5;
+    config.coordinates = true;
+
+    RGG2DFactory factory;
+    config = factory.NormalizeParameters(config, 0, 1, false);
+    auto generator = factory.Create(config, 0, 1);
+    generator->Generate(GraphRepresentation::EDGE_LIST);
+    const auto result = generator->Take();
+
+    // Creating the correct edge list as a test instance
+    std::vector<std::pair<SInt, SInt>> edgeList;
+    for (SInt i = 0; i < config.n; i++) {
+        for (SInt j = 0; j < config.n; j++) {
+            auto [x1, y1] = result.coordinates.first[i];
+            auto [x2, y2] = result.coordinates.first[j];
+            // Comparing all coordinates
+            if(i != j && std::hypot( x1- x2, y1 - y2) <= config.r) {
+                edgeList.push_back(std::pair(i, j));
+            }
+        }
+    }
+    // Sorting both lists before comparing them
+    std::vector<std::pair<SInt, SInt>> resultList = result.edges;
+    std::sort(resultList.begin(), resultList.end(), sortByFirstElement);
+    std::sort(edgeList.begin(), edgeList.end(), sortByFirstElement);
+    ASSERT_EQ(resultList, edgeList);
+}

--- a/tests/geometric/geometric_3d.cpp
+++ b/tests/geometric/geometric_3d.cpp
@@ -10,13 +10,13 @@
 
 using namespace kagen;
 
-TEST(GEOMETRIC, generates_graph_on_one_PE) {
+TEST(GEOMETRIC3D, generates_graph_on_one_PE) {
     PGeneratorConfig config;
     config.n           = 8;
     config.r           = 0.5;
     config.coordinates = true;
 
-    RGG2DFactory factory;
+    RGG3DFactory factory;
     config         = factory.NormalizeParameters(config, 0, 1, false);
     auto generator = factory.Create(config, 0, 1);
     generator->Generate(GraphRepresentation::EDGE_LIST);
@@ -25,11 +25,11 @@ TEST(GEOMETRIC, generates_graph_on_one_PE) {
     // Creating the correct edge list as a test instance
     std::vector<std::pair<SInt, SInt>> edgeList;
     for (SInt i = 0; i < config.n; i++) {
-        auto [x1, y1] = result.coordinates.first[i];
+        auto [x1, y1, z1] = result.coordinates.second[i];
         for (SInt j = 0; j < config.n; j++) {
-            auto [x2, y2] = result.coordinates.first[j];
+            auto [x2, y2, z2] = result.coordinates.second[j];
             // Comparing all coordinates
-            if (i != j && std::hypot(x1 - x2, y1 - y2) <= config.r) {
+            if (i != j && std::hypot(x1 - x2, y1 - y2, z1 - z2) <= config.r) {
                 edgeList.emplace_back(i, j);
             }
         }
@@ -41,13 +41,13 @@ TEST(GEOMETRIC, generates_graph_on_one_PE) {
     ASSERT_EQ(result.edges, edgeList);
 }
 
-TEST(GEOMETRIC, generates_graph_on_np_PE_n8_r50) {
+TEST(GEOMETRIC3D, generates_graph_on_np_PE_n8_r50) {
     PGeneratorConfig config;
     config.n           = 8;
     config.r           = 0.5;
     config.coordinates = true;
 
-    RGG2DFactory factory;
+    RGG3DFactory factory;
     PEID         size, rank;
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -57,18 +57,18 @@ TEST(GEOMETRIC, generates_graph_on_np_PE_n8_r50) {
     auto result = generator->Take();
 
     Graph complete_graph = kagen::testing::GatherEdgeLists(result);
-    auto global_graph = kagen::testing::GatherCoordinates2D(result);
+    auto global_graph = kagen::testing::GatherCoordinates3D(result);
 
     if (rank == 0) {
         // Creating the correct edge list as a test instance
         std::vector<std::pair<SInt, SInt>> edgeList;
         for (SInt i = 0; i < config.n; i++) {
-            auto [x1, y1] = global_graph.coordinates.first[i];
+            auto [x1, y1, z1] = global_graph.coordinates.second[i];
             for (SInt j = 0; j < config.n; j++) {
-                auto [x2, y2] = global_graph.coordinates.first[j];
+                auto [x2, y2, z2] = global_graph.coordinates.second[j];
 
                 // Comparing all coordinates
-                if (i != j && std::hypot(x1 - x2, y1 - y2) < config.r) {
+                if (i != j && std::hypot(x1 - x2, y1 - y2, z1 - z2) < config.r) {
                     edgeList.emplace_back(i, j);
                 }
             }
@@ -81,13 +81,13 @@ TEST(GEOMETRIC, generates_graph_on_np_PE_n8_r50) {
     }
 }
 
-TEST(GEOMETRIC, generates_graph_on_np_PE_n16_r20) {
+TEST(GEOMETRIC3D, generates_graph_on_np_PE_n16_r20) {
     PGeneratorConfig config;
     config.n           = 16;
     config.r           = 0.2;
     config.coordinates = true;
 
-    RGG2DFactory factory;
+    RGG3DFactory factory;
     PEID         size, rank;
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -97,18 +97,18 @@ TEST(GEOMETRIC, generates_graph_on_np_PE_n16_r20) {
     auto result = generator->Take();
 
     Graph complete_graph = kagen::testing::GatherEdgeLists(result);
-    auto global_graph = kagen::testing::GatherCoordinates2D(result);
+    auto global_graph = kagen::testing::GatherCoordinates3D(result);
 
     if (rank == 0) {
         // Creating the correct edge list as a test instance
         std::vector<std::pair<SInt, SInt>> edgeList;
         for (SInt i = 0; i < config.n; i++) {
-            auto [x1, y1] = global_graph.coordinates.first[i];
+            auto [x1, y1, z1] = global_graph.coordinates.second[i];
             for (SInt j = 0; j < config.n; j++) {
-                auto [x2, y2] = global_graph.coordinates.first[j];
+                auto [x2, y2, z2] = global_graph.coordinates.second[j];
 
                 // Comparing all coordinates
-                if (i != j && std::hypot(x1 - x2, y1 - y2) < config.r) {
+                if (i != j && std::hypot(x1 - x2, y1 - y2, z1 - z2) < config.r) {
                     edgeList.emplace_back(i, j);
                 }
             }
@@ -121,13 +121,13 @@ TEST(GEOMETRIC, generates_graph_on_np_PE_n16_r20) {
     }
 }
 
-TEST(GEOMETRIC, generates_graph_on_np_PE_n16_m50) {
+TEST(GEOMETRIC3D, generates_graph_on_np_PE_n16_m50) {
     PGeneratorConfig config;
     config.n           = 16;
     config.m           = 50;
     config.coordinates = true;
 
-    RGG2DFactory factory;
+    RGG3DFactory factory;
     PEID         size, rank;
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -137,18 +137,18 @@ TEST(GEOMETRIC, generates_graph_on_np_PE_n16_m50) {
     auto result = generator->Take();
 
     Graph complete_graph = kagen::testing::GatherEdgeLists(result);
-    auto global_graph = kagen::testing::GatherCoordinates2D(result);
+    auto global_graph = kagen::testing::GatherCoordinates3D(result);
 
     if (rank == 0) {
         // Creating the correct edge list as a test instance
         std::vector<std::pair<SInt, SInt>> edgeList;
         for (SInt i = 0; i < config.n; i++) {
-            auto [x1, y1] = global_graph.coordinates.first[i];
+            auto [x1, y1, z1] = global_graph.coordinates.second[i];
             for (SInt j = 0; j < config.n; j++) {
-                auto [x2, y2] = global_graph.coordinates.first[j];
+                auto [x2, y2, z2] = global_graph.coordinates.second[j];
 
                 // Comparing all coordinates
-                if (i != j && std::hypot(x1 - x2, y1 - y2) < config.r) {
+                if (i != j && std::hypot(x1 - x2, y1 - y2, z1 - z2) < config.r) {
                     edgeList.emplace_back(i, j);
                 }
             }
@@ -161,13 +161,13 @@ TEST(GEOMETRIC, generates_graph_on_np_PE_n16_m50) {
     }
 }
 
-TEST(GEOMETRIC, generates_graph_on_np_PE_m16_r50) {
+TEST(GEOMETRIC3D, generates_graph_on_np_PE_m16_r50) {
     PGeneratorConfig config;
     config.m           = 16;
     config.r           = 0.5;
     config.coordinates = true;
 
-    RGG2DFactory factory;
+    RGG3DFactory factory;
     PEID         size, rank;
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -177,18 +177,18 @@ TEST(GEOMETRIC, generates_graph_on_np_PE_m16_r50) {
     auto result = generator->Take();
 
     Graph complete_graph = kagen::testing::GatherEdgeLists(result);
-    auto global_graph = kagen::testing::GatherCoordinates2D(result);
+    auto global_graph = kagen::testing::GatherCoordinates3D(result);
 
     if (rank == 0) {
         // Creating the correct edge list as a test instance
         std::vector<std::pair<SInt, SInt>> edgeList;
         for (SInt i = 0; i < config.n; i++) {
-            auto [x1, y1] = global_graph.coordinates.first[i];
+            auto [x1, y1, z1] = global_graph.coordinates.second[i];
             for (SInt j = 0; j < config.n; j++) {
-                auto [x2, y2] = global_graph.coordinates.first[j];
+                auto [x2, y2, z2] = global_graph.coordinates.second[j];
 
                 // Comparing all coordinates
-                if (i != j && std::hypot(x1 - x2, y1 - y2) < config.r) {
+                if (i != j && std::hypot(x1 - x2, y1 - y2, z1 - z2) < config.r) {
                     edgeList.emplace_back(i, j);
                 }
             }


### PR DESCRIPTION
I have finished the testcases for geometric 2d and 3d. When transferring the test cases from 2D to 3D, I noticed that the number of chunks for 3D was assumed to be cubic. As a result, not all nodes or coordinates were created correctly. However, the number of nodes in the two-dimensional is the same as in the three-dimensional. If the chunks are calculated as in the two-dimensional case, then also all nodes and edges are created correctly. 