### PR TITLE
Fix RGG

### DIFF
--- a/kagen/generators/geometric/geometric_2d.h
+++ b/kagen/generators/geometric/geometric_2d.h
@@ -251,7 +251,9 @@ protected:
             cell_vertices.emplace_back(x, y, offset + i);
             // fprintf(edge_file, "v %f %f\n", x, y);
             if (push_coordinates && config_.coordinates) {
-                PushCoordinate(x, y);
+                if (IsLocalChunk(chunk_id)) {
+                    PushCoordinate(x, y);
+                }
             }
         }
         std::get<3>(cell) = true;

--- a/kagen/generators/geometric/geometric_2d.h
+++ b/kagen/generators/geometric/geometric_2d.h
@@ -52,6 +52,9 @@ protected:
             GenerateChunk(i);
 
         SetVertexRange(start_node_, start_node_ + num_nodes_);
+        if (config_.coordinates) {
+            CollectCoordinates();
+        }
     }
 
     // Config
@@ -214,7 +217,7 @@ protected:
         std::get<3>(chunk) = true;
     }
 
-    void GenerateVertices(const SInt chunk_id, const SInt cell_id, const bool push_coordinates) {
+    void GenerateVertices(const SInt chunk_id, const SInt cell_id, const bool /*push_coordinates*/) {
         // Lazily compute chunk
         if (chunks_.find(chunk_id) == end(chunks_))
             ComputeChunk(chunk_id);
@@ -249,14 +252,20 @@ protected:
             LPFloat y = mersenne.Random() * cell_size_ + start_y;
 
             cell_vertices.emplace_back(x, y, offset + i);
-            // fprintf(edge_file, "v %f %f\n", x, y);
-            if (push_coordinates && config_.coordinates) {
-                if (IsLocalChunk(chunk_id)) {
+        }
+        std::get<3>(cell) = true;
+    }
+
+    inline void CollectCoordinates() {
+        for (SInt chunk_id = local_chunk_start_; chunk_id < local_chunk_end_; chunk_id++) {
+            for (SInt i = 0; i < cells_per_chunk_; ++i) {
+                auto& cell_vertices = vertices_[ComputeGlobalCellId(chunk_id, i)];
+                for (auto& vertex : cell_vertices) {
+                    auto& [x, y, id] = vertex;
                     PushCoordinate(x, y);
                 }
             }
         }
-        std::get<3>(cell) = true;
     }
 
     void GenerateVertices(const SInt chunk_id, const SInt cell_id, std::vector<Vertex>& vertex_buffer) {

--- a/kagen/generators/geometric/geometric_3d.h
+++ b/kagen/generators/geometric/geometric_3d.h
@@ -52,6 +52,9 @@ protected:
             GenerateChunk(i);
 
         SetVertexRange(start_node_, start_node_ + num_nodes_);
+        if (config_.coordinates) {
+            CollectCoordinates();
+        }
     }
 
     // Config
@@ -265,7 +268,7 @@ protected:
         std::get<4>(chunk) = true;
     }
 
-    void GenerateVertices(const SInt chunk_id, const SInt cell_id, const bool push_coordinates) {
+    void GenerateVertices(const SInt chunk_id, const SInt cell_id, const bool /*push_coordinates*/) {
         // Lazily compute chunk
         if (chunks_.find(chunk_id) == end(chunks_)) {
             ComputeChunk(chunk_id);
@@ -304,15 +307,20 @@ protected:
             LPFloat z = mersenne_.Random() * cell_size_ + start_z;
 
             cell_vertices.emplace_back(x, y, z, offset + i);
-            // fprintf(edge_file, "v %f %f\n", x, y);
+        }
+        std::get<4>(cell) = true;
+    }
 
-            if (push_coordinates && config_.coordinates) {
-                if (IsLocalChunk(chunk_id)) {
+    inline void CollectCoordinates() {
+        for (SInt chunk_id = local_chunk_start_; chunk_id < local_chunk_end_; chunk_id++) {
+            for (SInt i = 0; i < cells_per_chunk_; ++i) {
+                auto& cell_vertices = vertices_[ComputeGlobalCellId(chunk_id, i)];
+                for (auto& vertex : cell_vertices) {
+                    auto& [x, y, z, id] = vertex;
                     PushCoordinate(x, y, z);
                 }
             }
         }
-        std::get<4>(cell) = true;
     }
 
     void GenerateVertices(const SInt chunk_id, const SInt cell_id, std::vector<Vertex>& vertex_buffer) {

--- a/kagen/generators/geometric/geometric_3d.h
+++ b/kagen/generators/geometric/geometric_3d.h
@@ -307,7 +307,9 @@ protected:
             // fprintf(edge_file, "v %f %f\n", x, y);
 
             if (push_coordinates && config_.coordinates) {
-                PushCoordinate(x, y, z);
+                if (IsLocalChunk(chunk_id)) {
+                    PushCoordinate(x, y, z);
+                }
             }
         }
         std::get<4>(cell) = true;

--- a/kagen/generators/geometric/rgg.cpp
+++ b/kagen/generators/geometric/rgg.cpp
@@ -131,7 +131,7 @@ RGG2DFactory::Create(const PGeneratorConfig& config, const PEID rank, const PEID
 
 PGeneratorConfig
 RGG3DFactory::NormalizeParameters(PGeneratorConfig config, PEID, const PEID size, const bool output) const {
-    EnsureSquarePowerOfTwoChunkSize(config, size, output);
+    EnsureCubicPowerOfTwoChunkSize(config, size, output);
 
     return NormalizeParametersCommon(config, &ApproxRadius3D, &ApproxNumNodes3D, output);
 }

--- a/kagen/generators/geometric/rgg/rgg_3d.cpp
+++ b/kagen/generators/geometric/rgg/rgg_3d.cpp
@@ -93,8 +93,8 @@ void RGG3D::GenerateGridEdges(
     // Check if vertices not generated
     SInt first_global_cell_id  = ComputeGlobalCellId(first_chunk_id, first_cell_id);
     SInt second_global_cell_id = ComputeGlobalCellId(second_chunk_id, second_cell_id);
-    GenerateVertices(first_chunk_id, first_cell_id, false);
-    GenerateVertices(second_chunk_id, second_cell_id, false);
+    GenerateVertices(first_chunk_id, first_cell_id, true);
+    GenerateVertices(second_chunk_id, second_cell_id, true);
 
     // Gather vertices
     if (vertices_.find(first_global_cell_id) == end(vertices_))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,11 +49,8 @@ kagen_add_test(test_geometric_one_PE
         
 kagen_add_test(geometric_2d_test
         FILES geometric/geometric_2d_test.cpp
-        CORES 1 2 4)
+        CORES 1 2 3 4 5 6)
 
 kagen_add_test(geometric_3d_test
         FILES geometric/geometric_3d_test.cpp
-        CORES 1 2 4)
-
-
-
+        CORES 1 2 3 4 5 6)

--- a/tests/geometric/geometric_2d_test.cpp
+++ b/tests/geometric/geometric_2d_test.cpp
@@ -81,3 +81,38 @@ TEST(Geometric2DTest, generates_graph_on_np_PE_n16_r10) {
         ASSERT_EQ(complete_graph.edges, edge_List);
     }
 }
+
+
+TEST(Geometric2DTest, generates_graph_on_np_PE_n512_r01) {
+    PGeneratorConfig config;
+    config.n           = 512;
+    config.r           = 0.01;
+    config.coordinates = true;
+
+    RGG2DFactory factory;
+    PEID         size, rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    config         = factory.NormalizeParameters(config, rank, size, false);
+    auto generator = factory.Create(config, rank, size);
+    generator->Generate(GraphRepresentation::EDGE_LIST);
+    generator->Finalize(MPI_COMM_WORLD);
+    auto result = generator->Take();
+
+    Graph complete_graph = kagen::testing::GatherEdgeLists(result);
+    auto  global_graph   = kagen::testing::GatherCoordinates2D(result);
+
+    if (rank == 0) {
+        ASSERT_EQ(config.n, global_graph.coordinates.first.size());
+
+        // Creating the correct edge list as a test instance
+        std::vector<std::pair<SInt, SInt>> edge_List =
+            kagen::testing::CreateExpectedRGG2DEdges(config, global_graph);
+
+        // Sorting both lists before comparing them
+        std::sort(complete_graph.edges.begin(), complete_graph.edges.end());
+        std::sort(edge_List.begin(), edge_List.end());
+
+        ASSERT_EQ(complete_graph.edges, edge_List);
+    }
+}

--- a/tests/geometric/geometric_3d_test.cpp
+++ b/tests/geometric/geometric_3d_test.cpp
@@ -78,3 +78,37 @@ TEST(Geometric3DTest, generates_graph_on_np_PE_n16_r10) {
         EXPECT_EQ(complete_graph.edges, edge_List);
     }
 }
+
+TEST(Geometric3DTest, generates_graph_on_np_PE_n512_r01) {
+    PGeneratorConfig config;
+    config.n           = 512;
+    config.r           = 0.01;
+    config.coordinates = true;
+
+    RGG3DFactory factory;
+    PEID         size, rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    config         = factory.NormalizeParameters(config, rank, size, false);
+    auto generator = factory.Create(config, rank, size);
+    generator->Generate(GraphRepresentation::EDGE_LIST);
+    generator->Finalize(MPI_COMM_WORLD);
+    auto result = generator->Take();
+
+    Graph complete_graph = kagen::testing::GatherEdgeLists(result);
+    auto  global_graph   = kagen::testing::GatherCoordinates3D(result);
+
+    if (rank == 0) {
+        EXPECT_EQ(config.n, global_graph.coordinates.second.size());
+
+        // Creating the correct edge list as a test instance
+        std::vector<std::pair<SInt, SInt>> edge_List =
+            kagen::testing::CreateExpectedRGG3DEdges(config, global_graph);
+
+        // Sorting both lists before comparing them
+        std::sort(complete_graph.edges.begin(), complete_graph.edges.end());
+        std::sort(edge_List.begin(), edge_List.end());
+
+        EXPECT_EQ(complete_graph.edges, edge_List);
+    }
+}

--- a/tests/geometric/geometric_3d_test.cpp
+++ b/tests/geometric/geometric_3d_test.cpp
@@ -31,7 +31,7 @@ TEST(Geometric3DTest, generates_graph_on_np_PE_n32_r125) {
     auto  global_graph   = kagen::testing::GatherCoordinates3D(result);
 
     if (rank == 0) {
-        ASSERT_EQ(config.n, global_graph.coordinates.second.size());
+        EXPECT_EQ(config.n, global_graph.coordinates.second.size());
 
         // Creating the correct edge list as a test instance
         std::vector<std::pair<SInt, SInt>> edge_List =
@@ -41,7 +41,7 @@ TEST(Geometric3DTest, generates_graph_on_np_PE_n32_r125) {
         std::sort(complete_graph.edges.begin(), complete_graph.edges.end());
         std::sort(edge_List.begin(), edge_List.end());
 
-        ASSERT_EQ(complete_graph.edges, edge_List);
+        EXPECT_EQ(complete_graph.edges, edge_List);
     }
 }
 
@@ -65,7 +65,7 @@ TEST(Geometric3DTest, generates_graph_on_np_PE_n16_r10) {
     auto  global_graph   = kagen::testing::GatherCoordinates3D(result);
 
     if (rank == 0) {
-        ASSERT_EQ(config.n, global_graph.coordinates.second.size());
+        EXPECT_EQ(config.n, global_graph.coordinates.second.size());
 
         // Creating the correct edge list as a test instance
         std::vector<std::pair<SInt, SInt>> edge_List =
@@ -75,6 +75,6 @@ TEST(Geometric3DTest, generates_graph_on_np_PE_n16_r10) {
         std::sort(complete_graph.edges.begin(), complete_graph.edges.end());
         std::sort(edge_List.begin(), edge_List.end());
 
-        ASSERT_EQ(complete_graph.edges, edge_List);
+        EXPECT_EQ(complete_graph.edges, edge_List);
     }
 }


### PR DESCRIPTION
The current RGG-3D implementation is broken, because it does not ensure a cubic number of PEs.
Also, coordinates were not collected properly, because due to the lazy cell generation, they were not collect in the right order.