### PR TITLE
Parsing of number of edges in option strings fallbacks to `1` if neither `m` or `M` is provided.

### DIFF
--- a/kagen/context.cpp
+++ b/kagen/context.cpp
@@ -331,7 +331,7 @@ PGeneratorConfig CreateConfigFromString(const std::string& options_str, PGenerat
     auto get_power_of_two_or_default = [&](const std::string& log_option, const std::string& option,
                                            const SInt default_value = 0) {
         if (options.count(log_option)) {
-            return 1ull << get_sint_or_default(log_option) // default value never used
+            return 1ull << get_sint_or_default(log_option); // default value never used
         }
         return get_sint_or_default(option, default_value);
     };

--- a/kagen/context.cpp
+++ b/kagen/context.cpp
@@ -328,9 +328,17 @@ PGeneratorConfig CreateConfigFromString(const std::string& options_str, PGenerat
         return generic_get_or_default(option, default_value, [](const std::string& value) { return value; });
     };
 
+    auto get_power_of_two_or_default = [&](const std::string& log_option, const std::string& option,
+                                           const SInt default_value = 0) {
+        if (options.count(log_option)) {
+            return 1ull << get_sint_or_default(log_option) // default value never used
+        }
+        return get_sint_or_default(option, default_value);
+    };
+
     config.generator   = type;
-    config.n           = get_sint_or_default("n", 1ull << get_sint_or_default("N"));
-    config.m           = get_sint_or_default("m", 1ull << get_sint_or_default("M"));
+    config.n           = get_power_of_two_or_default("N", "n");
+    config.m           = get_power_of_two_or_default("M", "m");
     config.k           = get_sint_or_default("k");
     config.seed        = get_sint_or_default("seed", config.seed);
     config.p           = get_hpfloat_or_default("prob", get_hpfloat_or_default("p"));


### PR DESCRIPTION
This defaults to $2^M = 1$.
``` c++
    config.n           = get_sint_or_default("n", 1ull << get_sint_or_default("N"));
    config.m           = get_sint_or_default("m", 1ull << get_sint_or_default("M"));
```